### PR TITLE
Fix typo in cntlm.service.j2

### DIFF
--- a/templates/cntlm.service.j2
+++ b/templates/cntlm.service.j2
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=forking
 
-ExecStart=/usr/sbin/cntlm -c /etc/cntlm.conf -f {{ cntlm_options | default([] }}
+ExecStart=/usr/sbin/cntlm -c /etc/cntlm.conf -f {{ cntlm_options | default([]) }}
 ExecStop=pkill cntlm
 
 [Install]


### PR DESCRIPTION
```
TASK [robertdebock.cntlm : register cntlm to a systemd system] **********************************************************************************************************
fatal: [proxy]: FAILED! => {"changed": false, "msg": "AnsibleError: template error while templating string: unexpected '}', expected ')'. String: {{ ansible_managed | comment }}\n[Unit]\nDescription=cntlm\nAfter=network.target\n\n[Service]\nType=forking\n\nExecStart=/usr/sbin/cntlm -c /etc/cntlm.conf -f {{ cntlm_options | default([] }}\nExecStop=pkill cntlm\n\n[Install]\nWantedBy=multi-user.target\n"}
```