### PR TITLE
Allow including local IP in cntlm_allows

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ cntlm_listen: 3128
 # When you've got a password hash, you may fill it in here.
 # cntlm_passntlmv2: 1234567890abcdef
 
+# When using NTLM authentication (not NTLMv2), set to true:
+cntlm_auth_ntlm: false
+
 # What hosts to omit in the proxy.
 cntlm_noproxy: localhost
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ cntlm_denies:
 
 # If yes, access to CNTLM is possible from outside of the local host, subject to cntlm_allows and cntlm_denies:
 gateway_enabled: "no"
+
+# If "yes", include the default ansible_default_ipv4 IP in cntlm_allows ([inventory_hostname]['ansible_default_ipv4'])
+cntlm_allows_include_local_ipv4: "no"
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,9 @@ cntlm_tmp: /root
 cntlm_allows:
   - "127.0.0.1"
 
+# If "yes", include the default ansible_default_ipv4 IP in cntlm_allows ([inventory_hostname]['ansible_default_ipv4'])
+cntlm_allows_include_local_ipv4: "no"
+
 # By default ("0/0"), CNTLM is inaccessible from all other IP addresses.
 cntlm_denies:
   - "0/0"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ cntlm_listen: 3128
 
 # When you've got a password hash, you may fill it in here.
 # cntlm_passntlmv2: 1234567890abcdef
+cntlm_auth_ntlm: false
 
 # What hosts to omit in the proxy.
 cntlm_noproxy: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,11 @@
     name: "{{ cntlm_requirements }}"
     state: present
 
+- name: include local IP in cntlm_allows
+  set_fact:
+    cntlm_allows: "{{ cntlm_allows + [ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] + '/32'] }}"
+  when: cntlm_allows_include_local_ipv4 == "yes"
+
 - name: unpack cntlm software
   ansible.builtin.unarchive:
     src: "{{ cntlm_sourceforge_mirror }}/{{ cntlm_archive }}"

--- a/templates/cntlm.conf.j2
+++ b/templates/cntlm.conf.j2
@@ -5,6 +5,9 @@ Proxy {{ cntlm_proxy }}
 Listen {{ cntlm_listen }}
 {% if cntlm_passntlmv2 is defined %}
 PassNTLMv2 {{ cntlm_passntlmv2 }}
+{% elif cntlm_auth_ntlm %}
+Auth NTLM
+{{ cntlm_generate_hash.stdout_lines[2] }}
 {% else %}
 {{ cntlm_generate_hash.stdout_lines[3] }}
 {% endif %}


### PR DESCRIPTION
Added boolean that, when `true`, appends `ansible_default_ipv4` hostvar to `cntlm_allows` list. Useful to setup eg docker engine to use cntlm.  Defaults to false, so non-breaking

I notice my [last PR](https://github.com/robertdebock/ansible-role-cntlm/pull/9) wasn't reviewed. Pls advise if you aren't accepting PRs and I won't create any more.